### PR TITLE
Add backend and frontend services to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,39 @@ services:
     networks:
       - peptok-network
 
+  backend:
+    build:
+      context: ./backend-nestjs
+      dockerfile: Dockerfile
+    container_name: peptok-backend
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: peptok_user
+      DATABASE_PASSWORD: peptok_password
+      DATABASE_NAME: peptok_dev
+      REDIS_URL: redis://redis:6379
+      JWT_SECRET: your-super-secret-jwt-key-change-in-production
+      PORT: 3000
+      FRONTEND_URL: http://frontend:80
+    ports:
+      - "3001:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    networks:
+      - peptok-network
+
   frontend:
     build:
       context: .
@@ -59,38 +92,6 @@ services:
       interval: 30s
       timeout: 3s
       start_period: 5s
-      retries: 3
-    networks:
-      - peptok-network
-
-  backend:
-    build:
-      context: ./backend-nestjs
-      dockerfile: Dockerfile
-    container_name: peptok-backend
-    restart: unless-stopped
-    environment:
-      NODE_ENV: production
-      DATABASE_HOST: postgres
-      DATABASE_PORT: 5432
-      DATABASE_USER: peptok_user
-      DATABASE_PASSWORD: peptok_password
-      DATABASE_NAME: peptok_dev
-      REDIS_URL: redis://redis:6379
-      JWT_SECRET: your-super-secret-jwt-key-change-in-production
-      PORT: 3000
-    ports:
-      - "3001:3000"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-            healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 10s
-      start_period: 30s
       retries: 3
     networks:
       - peptok-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   postgres:
     image: postgres:15-alpine
@@ -10,7 +8,7 @@ services:
       POSTGRES_USER: peptok_user
       POSTGRES_PASSWORD: peptok_password
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend-nestjs/sql/init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -19,6 +17,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - peptok-network
 
   redis:
     image: redis:7-alpine
@@ -33,6 +33,63 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - peptok-network
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: peptok-frontend
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost/",
+        ]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+    networks:
+      - peptok-network
+
+  backend:
+    build:
+      context: ./backend-nestjs
+      dockerfile: Dockerfile
+    container_name: peptok-backend
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://peptok_user:peptok_password@postgres:5432/peptok_dev
+      REDIS_URL: redis://redis:6379
+      JWT_SECRET: your-super-secret-jwt-key-change-in-production
+      PORT: 3000
+    ports:
+      - "3001:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    networks:
+      - peptok-network
 
 volumes:
   postgres_data:
@@ -41,5 +98,5 @@ volumes:
     driver: local
 
 networks:
-  default:
-    name: peptok-network
+  peptok-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-        healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/v1/health"]
+            healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
       timeout: 10s
       start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+        healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/v1/health"]
       interval: 30s
       timeout: 10s
       start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    healthcheck:
+        healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       dockerfile: Dockerfile
     container_name: peptok-backend
     restart: unless-stopped
-        environment:
+    environment:
       NODE_ENV: production
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
@@ -86,7 +86,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-        healthcheck:
+    healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,13 @@ services:
       dockerfile: Dockerfile
     container_name: peptok-backend
     restart: unless-stopped
-    environment:
+        environment:
       NODE_ENV: production
-      DATABASE_URL: postgresql://peptok_user:peptok_password@postgres:5432/peptok_dev
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: peptok_user
+      DATABASE_PASSWORD: peptok_password
+      DATABASE_NAME: peptok_dev
       REDIS_URL: redis://redis:6379
       JWT_SECRET: your-super-secret-jwt-key-change-in-production
       PORT: 3000


### PR DESCRIPTION
- Remove version specification from docker-compose.yml
- Change postgres port mapping from 5432:5432 to 5433:5432
- Add explicit peptok-network to postgres and redis services
- Add new backend service with NestJS build configuration
- Add new frontend service with Docker build configuration
- Configure service dependencies and health checks for all services
- Replace default network with explicit peptok-network bridge driver
- Expose backend on port 3001 and frontend on port 8080

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1669a51e06a94b13825369ecc7d11960/zen-garden)

👀 [Preview Link](https://1669a51e06a94b13825369ecc7d11960-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1669a51e06a94b13825369ecc7d11960</projectId>-->
<!--<branchName>zen-garden</branchName>-->